### PR TITLE
自分が場に出したカードの並びが左詰めじゃなくなるバグの修正

### DIFF
--- a/public/game.html
+++ b/public/game.html
@@ -632,8 +632,8 @@
                     const playedImg = document.createElement("img");
                     playedImg.src = `../images/${card}.jpg`;
                     playedImg.classList.add("played-card");
-                    playedImg.position = "absolute";
-                    playedImg.left = `${index * 40}px`;
+                    playedImg.style.position = "absolute";
+                    playedImg.style.left = `${index * 40}px`;
                     playedImg.zIndex = index;
                     playedImg.style.width = "100px";
                     playedImg.style.height = "150px";

--- a/run_server
+++ b/run_server
@@ -3,11 +3,11 @@
 cat origin.json > data.json
 
 # ローカルの開発環境として起動
-# npm run dev
+npm run dev
 
 # ホストとして起動
-inet=$(ifconfig | grep "inet 10")
-port=':3000'
-url=${inet:5:12}${port}
-echo $url
-npm run dev -- --host
+# inet=$(ifconfig | grep "inet 10")
+# port=':3000'
+# url=${inet:5:12}${port}
+# echo $url
+# npm run dev -- --host


### PR DESCRIPTION
#4  自分の場に出されたカードが中央から並び、左詰めじゃなくなるバグを修正。
game.htmlの635,636行目のcssの情報をjs側で書き換える処理でstyleが抜けていたため、正しく設定できていなかったのでstyleをつけて修正。