### PR TITLE
fix:Card1の時に相手のドローを待たずにtrushに入るのを修正

### DIFF
--- a/public/src/card.js
+++ b/public/src/card.js
@@ -83,7 +83,7 @@ class Card1 extends Card {
             if (opponent && this.field.deck.length > 0) {
                 const getNumber = opponent.get;
                 opponent.get = 1;
-                field.draw(opponent, roomId);
+                await field.draw(opponent, roomId);
                 opponent.get = getNumber;
                 
                 const opponentHands = [...opponent.hands];


### PR DESCRIPTION
カード1を使用した際に相手がドローし終わる前にtrushの選択画面に入るバグを修正。
awaitを使用してドローが終わるのを待つように変更。