### PR TITLE
fix:カード8で次のターンまで入れ替わりが表示に反映されないバグを修正

### DIFF
--- a/public/game.html
+++ b/public/game.html
@@ -1345,6 +1345,8 @@
                     callback([playerSelect])
                 }
                 console.log(`playerSelect: ${playerSelect}`)
+            }else if(data.kind == 'update'){
+                callback([0])
             }else{
                 try {
                     let playerSelect = await select(data.choices);

--- a/public/src/card.js
+++ b/public/src/card.js
@@ -293,6 +293,13 @@ class Card8 extends Card {
             player.look.push({ opponent, card: opponent.hands[0] });
             opponent.looked.push({ subject: player, card: opponent.hands[0] });
             player.looked.push({ subject: opponent, card: player.hands[0] });
+            const responce = await choice(
+                createData(this.field, player),
+                ["", ""],
+                'update',
+                player.socketId,
+                roomId
+            )
         }
     }
 }


### PR DESCRIPTION
#8 カードの表示がデータに追いついていないのが原因だった。
データでは正しく入れ替わっていた。
8のカードの効果が発動した後に画面更新の命令をクライアントに飛ばすように修正。
プレイヤー2人の画面が更新されて入れ替わったカードを瞬時に表示できる。