### PR TITLE
fix:Card7の発動後の3択から選ぶとアニメーションの画像が選択カードのものでなくなるバグを修正　

### DIFF
--- a/public/game.html
+++ b/public/game.html
@@ -1322,11 +1322,14 @@
             console.log(data.kind)
             if(data.kind=='draw'){
                 if(data.choices.length>2){
-                    let playerSelect =  await select(data.choices);
+                    let playerSelectNumber =  await select(data.choices);
                     selectContainer.style.display = 'none';
-                    const done = await drawCardToHand(playerSelect)
+                    console.log('playerSelectNumber');
+                    console.log(playerSelectNumber);
+                    let playerSelectCard = data.choices[playerSelectNumber];
+                    const done = await drawCardToHand(playerSelectCard)
                     if(done == 'done'){
-                        callback([playerSelect])
+                        callback([playerSelectNumber])
                     }
                 }else{
                     const done = await drawCardToHand(data.choices[0])

--- a/public/src/field.js
+++ b/public/src/field.js
@@ -25,10 +25,8 @@ class Field {
         let deck = [];
         for (let number = 0; number < 10; number++) {
             if (number + 1 <= 8) {
-                if (number != 100){
-                    for (let _ = 0; _ < 2; _++) {
-                        deck.push(cards[number]);
-                    }
+                for (let _ = 0; _ < 2; _++) {
+                    deck.push(cards[number]);
                 }
             } else {
                 deck.push(cards[number]);


### PR DESCRIPTION
カード7の効果で3択からカードを選ぶと選択したカードと違うカードの画像でドローのアニメーションが再生されるバグを修正。
アニメーション関数に渡される引数の型がドローしたカードではなく、ドローしたカードのインデックスで整数値が渡されていたため、バグが発生していた。ドローしたカードを正しい型でアニメーション関数に渡すように修正。