### PR TITLE
fix:カード1とカード10のtrush後のカードが相手のプレイエリアに行かないバグを修正

### DIFF
--- a/public/src/card.js
+++ b/public/src/card.js
@@ -106,7 +106,7 @@ class Card1 extends Card {
                 
                 const trushIndex = opponent.hands.findIndex(card => card.number === cardNumber);
                 const trushCard = opponent.hands.splice(trushIndex, 1)[0];
-                field.played[player.turnNumber - 1].push(trushCard);
+                field.played[opponent.turnNumber - 1].push(trushCard);
                 
                 if (trushCard.number === 10) {
                     this.kill10(opponent);
@@ -341,7 +341,7 @@ class Card9 extends Card {
             
             const choiceIndex = opponent.hands.findIndex(card => card.number === choiceNumber);
             const trushCard = opponent.hands.splice(choiceIndex, 1)[0];
-            this.field.played[player.turnNumber - 1].push(trushCard);
+            this.field.played[opponent.turnNumber - 1].push(trushCard);
             
             if (trushCard.number === 10) {
                 this.kill(opponent);


### PR DESCRIPTION
カード1とカード9でカードをtrushすると相手のプレイエリアではなく、自分のプレイエリアに行くバグが発生。
プレイした後の判定にするのが、プレイヤーになっていたため、opponentに変更。
fix: #12 