### PR TITLE
fix:Card5DupulicateCard

### DIFF
--- a/public/src/card.js
+++ b/public/src/card.js
@@ -213,10 +213,10 @@ class Card5 extends Card {
         if (opponent && this.field.deck.length > 0) {
             const getNumber = opponent.get;
             opponent.get = 1;
-            this.field.draw(opponent, roomId);
+            await this.field.draw(opponent, roomId);
             opponent.get = getNumber;
             
-            const randomIndex = Math.floor(Math.random() * opponent.hands.length);
+            const randomIndex = Math.floor(Math.random() * opponent.hands.length + 1); // opponent.hands.length分ランダムにするためには+1が必要
             const dropCard = opponent.hands.splice(randomIndex, 1)[0];
             opponent.looked.push({ subject: player, card: dropCard });
             this.field.played[opponent.turnNumber - 1].push(dropCard);


### PR DESCRIPTION
カード5内で呼ばれているドローの処理がawaitされていないため起きていた。
awaitして、修正。
また、カード5の捨てられるカードがランダムになっていなかったため、ランダムになるようにしゅうせい。