### PR TITLE
fix:Card5で生じるバグを修正

### DIFF
--- a/public/src/card.js
+++ b/public/src/card.js
@@ -216,7 +216,7 @@ class Card5 extends Card {
             await this.field.draw(opponent, roomId);
             opponent.get = getNumber;
             
-            const randomIndex = Math.floor(Math.random() * opponent.hands.length + 1); // opponent.hands.length分ランダムにするためには+1が必要
+            const randomIndex = Math.floor(Math.random() * opponent.hands.length + 1) - 1; // opponent.hands.length分ランダムにするためには+1が必要
             const dropCard = opponent.hands.splice(randomIndex, 1)[0];
             opponent.looked.push({ subject: player, card: dropCard });
             this.field.played[opponent.turnNumber - 1].push(dropCard);


### PR DESCRIPTION
カード5で発生するTypeErrorを解決。
相手のカードから捨てさせるのをランダムで決定する際に1~2でランダムになっていた。
2の場合にはindexが相手の手札の最大値2枚目を超すためエラーだった。
-1して0~1の範囲のランダムの数にして対応した。
fix #41 