### PR TITLE
fix:CPU対戦だとリザルト画面に遷移できないバグを修正

### DIFF
--- a/server.js
+++ b/server.js
@@ -407,23 +407,26 @@ io.on('connection', (socket) => {
       
       if(result[0]){
         const gameLog = result[1]
-        for(let i=0; i<jsonData.rooms[data.roomId].players.length; i++){
-          const player = game.field.players[i]
-          const result = gameLog[i][gameLog[i].length - 1]
-          const currentPlayerId = jsonData.rooms[data.roomId].players[i];
-          jsonData.players[currentPlayerId].ready = 0;
-
-          console.log(`[サーバー送信前チェック] 送信するplayerId: ${currentPlayerId}`);
+        for(let i=0; i<game.field.players.length; i++){
+          const player = game.field.players[i];
+          const result = gameLog[player.turnNumber - 1][gameLog[player.turnNumber - 1].length - 1]
+          let currentPlayerId = "";
+          for(let j=0; j<jsonData.rooms[data.roomId].players.length; j++){
+            currentPlayerId = jsonData.rooms[data.roomId].players[j];
+            if (jsonData.players[currentPlayerId].socketId == player.socketId){
+              jsonData.players[currentPlayerId].ready = 0;
+              io.to(player.socketId).emit('gameEnded', { 
+                  result: result,
+                  roomId: data.roomId,
+                  playerId: currentPlayerId 
+              });
+            };
+          }
 
           io.to(player.socketId).emit('result', {result: result})
-          io.to(player.socketId).emit('gameEnded', { 
-              result: result,
-              roomId: data.roomId,
-              playerId: currentPlayerId 
-          });
-          for(let k=0; k<gameLog[i].length; k++){
-            console.log(gameLog[i][k])
-          }
+          // for(let k=0; k<gameLog[i].length; k++){
+          //   console.log(gameLog[i][k])
+          // }
           console.log(`${player.name}: ${result}`)
         }
         // 変更を保存


### PR DESCRIPTION
CPU対戦の場合にリザルト画面に遷移できないバグを修正。
gameを実行しているプログラム側と通信を制御しているサーバー側で2つのプレイヤーリストがあり、別々のリストを同じインデックスで参照していたのが問題。
二つのリストは並びが別々な場合があり、同じインデックスを使うと別々の要素をしていることがある。
->基本的に一つのリストを使用するようにする。しかし、どうしても別々のリストを使う必要があるときはsocketIdで同一のものを同じ要素として判定して、同じplayerと確認してから操作するように変更。

fix: #88 