### PR TITLE
fix:cpu対戦後の再戦でもcpuとpvpを選択できるようにする

### DIFF
--- a/server.js
+++ b/server.js
@@ -456,10 +456,8 @@ io.on('connection', (socket) => {
         console.log(`${playerId} からルーム ${roomId} への再戦リクエストを受け取りました。`);
         const room = jsonData.rooms[roomId];
 
-        if (room.players.length >= 2) {
-            console.log(`ルーム ${roomId} の初回再戦リクエスト。プレイヤーリストをリセットします。`);
-            room.players = []; // ここで部屋を空にする
-        }
+        console.log(`ルーム ${roomId} の初回再戦リクエスト。プレイヤーリストをリセットします。`);
+        room.players = []; // ここで部屋を空にする
         room.players.push(playerId);
         console.log(`ルーム ${roomId} に ${playerId} が参加。現在のメンバー:`, room.players)
 


### PR DESCRIPTION
cpu対戦後にreplayをするとcpu対戦が強制的に始まる件について、cpuとpvpを選択できるパネルの表示をできるようにした。
playerのリストの初期化がroomの人数が2人以上の場合にしか行われていなかったので、全てのパターンで初期化するように変更。
fix: #89 